### PR TITLE
feat: add option to not warn for read-only streams

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
+++ b/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
@@ -40,6 +40,9 @@ public class CommandLineInterface {
   public static final String QUIET_OPTION = "quiet";
   public static final String QUIET_DESC = "Print minimum status update";
 
+  public static final String DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION = "accept-read-only-streams";
+  public static final String DONT_WARN_FOR_READ_ONLY_STREAMS_DESC =
+      "Don't warn for streams that only have readers. Use this if you abuse streams to have a lazy person's consumers with state.";
   public static final String VALIDATE_OPTION = "validate";
   public static final String VALIDATE_DESC = "Only run configured validations in your topology";
 
@@ -109,6 +112,14 @@ public class CommandLineInterface {
             .required(false)
             .build();
 
+    final Option dontWarnForReadOnlyStreamsOption =
+        Option.builder()
+            .longOpt(DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION)
+            .hasArg(false)
+            .desc(DONT_WARN_FOR_READ_ONLY_STREAMS_DESC)
+            .required(false)
+            .build();
+
     final Option quietOption =
         Option.builder()
             .longOpt(QUIET_OPTION)
@@ -146,6 +157,7 @@ public class CommandLineInterface {
     options.addOption(overridingAdminClientConfigFileOption);
     options.addOption(dryRunOption);
     options.addOption(recursiveOption);
+    options.addOption(dontWarnForReadOnlyStreamsOption);
     options.addOption(quietOption);
     options.addOption(validateOption);
     options.addOption(versionOption);

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -392,6 +392,12 @@ public class Configuration {
     return config.getBoolean(ALLOW_DELETE_KSQL_ARTEFACTS);
   }
 
+  public boolean isWarnIfReadOnlyStreams() {
+    return !Boolean.parseBoolean(
+            cliParams.getOrDefault(DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION, "false"))
+        && config.getBoolean(STREAMS_WARN_IF_READ_ONLY);
+  }
+
   public boolean enabledPrincipalTranslation() {
     return config.getBoolean(TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG);
   }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -82,7 +82,7 @@ public class Constants {
   static final String ALLOW_DELETE_PRINCIPALS = "allow.delete.principals";
   public static final String ALLOW_DELETE_CONNECT_ARTEFACTS = "allow.delete.artefacts.connect";
   public static final String ALLOW_DELETE_KSQL_ARTEFACTS = "allow.delete.artefacts.ksql";
-
+  public static final String STREAMS_WARN_IF_READ_ONLY = "streams.warn-if.read-only";
   public static final String JULIE_ENABLE_PRINCIPAL_MANAGEMENT =
       "julie.enable.principal.management";
 

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
@@ -423,15 +423,15 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
 
     for (KStream ks : streams) {
       var topics = ks.getTopics();
-      if (topics.get(KStream.READ_TOPICS).isEmpty() || topics.get(KStream.WRITE_TOPICS).isEmpty()) {
+      if (topics.get(KStream.WRITE_TOPICS).isEmpty() && config.isWarnIfReadOnlyStreams()) {
         LOGGER.warn(
             "A Kafka Streams application with Id ("
                 + ks.getApplicationId()
                 + ") and Principal ("
                 + ks.getPrincipal()
                 + ")"
-                + " might require both read and write topics as per its "
-                + "nature it is always reading and writing into Apache Kafka, be aware if you notice problems.");
+                + " might require both read and write topics, as per its "
+                + "nature, it is always reading and writing into Apache Kafka.");
       }
       if (topics.get(KStream.READ_TOPICS).isEmpty()) {
         // should have at minimum read topics defined as we could think of write topics as internal

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -101,7 +101,6 @@ julie {
     verify.remote.state = false
     verify.remote.state = ${?JULIE_VERIFY_REMOTE_STATE}
 
-
     audit {
        enabled = false
        enabled = ${?JULIE_AUDIT_ENABLED}
@@ -175,4 +174,8 @@ validations {
         op = "gte"
         value = 3
     }
+}
+
+streams {
+    warn-if.read-only = true
 }

--- a/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Condition;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -335,5 +336,19 @@ public class ConfigurationTest {
     props.put(SERVICE_ACCOUNT_MANAGED_PREFIXES + ".0", "");
     Configuration config = new Configuration(cliOps, props);
     config.validateWith(topology);
+  }
+
+  @Test
+  public void shouldWarnForReadOnlyStreamsByDefaultToKeepBackwardsCompatibility() {
+    Configuration config = new Configuration(cliOps, props);
+    Assert.assertTrue(config.isWarnIfReadOnlyStreams());
+  }
+
+  @Test
+  public void shouldOverrideWarnForReadOnlyStreamsFromCommandLine() {
+    Map<String, String> localCliOps = new HashMap<>();
+    localCliOps.put(CommandLineInterface.DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION, "true");
+    Configuration config = new Configuration(localCliOps, props);
+    Assert.assertFalse(config.isWarnIfReadOnlyStreams());
   }
 }


### PR DESCRIPTION
Some people use read-only streams on purpose, to have cheap "consumers with state".
